### PR TITLE
Prepare release 1.6.0

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -3,4 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-1.6.0
+user=hifis-net
+project=ansible-role-haproxy
+since-tag=v1.5.0
+base=HISTORY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,33 @@
 # Changelog
 
-## [Unreleased](https://github.com/hifis-net/ansible-role-haproxy/tree/HEAD)
+## [v1.6.0](https://github.com/hifis-net/ansible-role-haproxy/tree/v1.6.0) (2022-08-16)
 
-[Full Changelog](https://github.com/hifis-net/ansible-role-haproxy/compare/v1.5.0...HEAD)
+[Full Changelog](https://github.com/hifis-net/ansible-role-haproxy/compare/v1.5.0...v1.6.0)
+
+**Implemented enhancements:**
+
+- Support Ubuntu 22.04 [\#28](https://github.com/hifis-net/ansible-role-haproxy/issues/28)
+- Migrate changelog to github-changelog-generator [\#7](https://github.com/hifis-net/ansible-role-haproxy/issues/7)
 
 **Merged pull requests:**
 
+- Remove renovate.json [\#32](https://github.com/hifis-net/ansible-role-haproxy/pull/32) ([Normo](https://github.com/Normo))
+- Use Python 3.10 in the project [\#30](https://github.com/hifis-net/ansible-role-haproxy/pull/30) ([tobiashuste](https://github.com/tobiashuste))
+- Add support for Ubuntu 22.04 [\#29](https://github.com/hifis-net/ansible-role-haproxy/pull/29) ([tobiashuste](https://github.com/tobiashuste))
+- Use molecule-podman instead of molecule-docker [\#27](https://github.com/hifis-net/ansible-role-haproxy/pull/27) ([tobiashuste](https://github.com/tobiashuste))
+- Bump ansible from 5.7.1 to 6.2.0 [\#26](https://github.com/hifis-net/ansible-role-haproxy/pull/26) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump ansible-lint from 6.0.2 to 6.4.0 [\#25](https://github.com/hifis-net/ansible-role-haproxy/pull/25) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump molecule from 3.6.1 to 4.0.1 [\#24](https://github.com/hifis-net/ansible-role-haproxy/pull/24) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump yamllint from 1.26.3 to 1.27.1 [\#22](https://github.com/hifis-net/ansible-role-haproxy/pull/22) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump robertdebock/galaxy-action from 1.2.0 to 1.2.1 [\#16](https://github.com/hifis-net/ansible-role-haproxy/pull/16) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump reuse from 0.14.0 to 1.0.0 [\#15](https://github.com/hifis-net/ansible-role-haproxy/pull/15) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump ansible from 5.6.0 to 5.7.1 [\#10](https://github.com/hifis-net/ansible-role-haproxy/pull/10) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Migrate manual changelog to github-changelog-generator [\#8](https://github.com/hifis-net/ansible-role-haproxy/pull/8) ([Normo](https://github.com/Normo))
 - Bump molecule from 3.6.0 to 3.6.1 [\#6](https://github.com/hifis-net/ansible-role-haproxy/pull/6) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump ansible-lint from 5.3.2 to 6.0.2 [\#5](https://github.com/hifis-net/ansible-role-haproxy/pull/5) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump ansible from 5.3.0 to 5.6.0 [\#4](https://github.com/hifis-net/ansible-role-haproxy/pull/4) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Add badges to README.md [\#3](https://github.com/hifis-net/ansible-role-haproxy/pull/3) ([Normo](https://github.com/Normo))
 - Implement GitHub actions workflows [\#1](https://github.com/hifis-net/ansible-role-haproxy/pull/1) ([Normo](https://github.com/Normo))
-
-<!--
-SPDX-FileCopyrightText: 2020 Helmholtz Centre for Environmental Research (UFZ)
-SPDX-FileCopyrightText: 2020 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
-
-SPDX-License-Identifier: Apache-2.0
--->
 
 ## [v1.5.0](https://github.com/hifis-net/ansible-role-haproxy/releases/tag/v1.5.0) - 2022-02-22
 

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+
+SPDX-License-Identifier: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+# SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
+
+# SPDX-License-Identifier: Apache-2.0
+
+cff-version: '1.2.0'
+title: 'hifis.haproxy Ansible role'
+message: >-
+  "If you use this Ansible role, please cite it as
+  below."
+abstract: 'Ansible role to set up HAProxy.'
+type: 'software'
+authors:
+  - given-names: 'Norman'
+    family-names: 'Ziegner'
+    email: 'norman.ziegner@ufz.de'
+    affiliation: >-
+      Helmholtz Centre for Environmental Research
+      GmbH - UFZ
+    orcid: 'https://orcid.org/0000-0001-7579-216X'
+  - given-names: 'Tobias'
+    family-names: 'Huste'
+    email: 't.huste@hzdr.de'
+    affiliation: >-
+      Helmholtz-Zentrum Dresden-Rossendorf e. V.
+      (HZDR)
+    orcid: 'https://orcid.org/0000-0002-5590-7473'
+  - given-names: 'Christian'
+    family-names: 'Hüser'
+    email: 'c.hueser@hzdr.de'
+    affiliation: >-
+      Helmholtz-Zentrum Dresden-Rossendorf e. V.
+      (HZDR)
+    orcid: 'https://orcid.org/0000-0002-5028-6663'
+repository-code: 'https://github.com/hifis-net/ansible-role-haproxy'
+repository-artifact: 'https://galaxy.ansible.com/hifis/haproxy'
+version: 'v1.6.0'
+date-released: '2022-08-16'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2020 Helmholtz Centre for Environmental Research (UFZ)
-SPDX-FileCopyrightText: 2020 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
-
-SPDX-License-Identifier: Apache-2.0
--->
-
 ## [v1.5.0](https://github.com/hifis-net/ansible-role-haproxy/releases/tag/v1.5.0) - 2022-02-22
 
 [List of commits](https://github.com/hifis-net/ansible-role-haproxy/compare/v1.4.0...v1.5.0)

--- a/HISTORY.md.license
+++ b/HISTORY.md.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
* Add a `CITATION.cff` to create a release on Zenodo
* Add a default configuration for the github changelog generator
* Prepare release 1.6.0

Closes #31