### PR TITLE
Support HAProxy 2.4 and 2.6 and default to 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Currently [supported platforms](meta/main.yml) are:
 This role is tested against the two latest LTS versions of HAProxy.
 Currently, this results in official support for the HAProxy release series:
 
+- `2.6`
 - `2.4`
-- `2.2`
 
 Other versions are known to work as well but are not automatically tested.
 
@@ -126,7 +126,7 @@ haproxy_executable_path: '/usr/sbin/haproxy'
 Variable to pin the PPA version to a certain value:
 
 ```yaml
-haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
+haproxy_ppa_version: 'ppa:vbernat/haproxy-2.6'
 ```
 
 #### HAProxy version
@@ -134,7 +134,7 @@ haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
 Variable to pin the HAProxy version to a certain value:
 
 ```yaml
-haproxy_version: '2.4.*'
+haproxy_version: '2.6.*'
 ```
 
 #### HAProxy user

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,9 @@
 # Path to the executable of HAProxy
 haproxy_executable_path: '/usr/sbin/haproxy'
 # HAProxy PPA version
-haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
+haproxy_ppa_version: 'ppa:vbernat/haproxy-2.6'
 # HAProxy version
-haproxy_version: '2.4.*'
+haproxy_version: '2.6.*'
 # HAProxy user
 haproxy_user: 'haproxy'
 # HAProxy group

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,13 +37,13 @@ provisioner:
     host_vars:
       instance_haproxy_1:
         haproxy_create_self_signed_cert: true
-        haproxy_ppa_version: 'ppa:vbernat/haproxy-2.2'
-        haproxy_version: '2.2.*'
+        haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
+        haproxy_version: '2.4.*'
       instance_haproxy_2:
         haproxy_create_self_signed_cert: false
         haproxy_ssl_cert_chain_src_file_path: "{{ (lookup('env', 'MOLECULE_SCENARIO_DIRECTORY'), 'test.pem') | path_join }}"
-        haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
-        haproxy_version: '2.4.*'
+        haproxy_ppa_version: 'ppa:vbernat/haproxy-2.6'
+        haproxy_version: '2.6.*'
   playbooks:
     prepare: prepare.yml
     check: converge.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -35,11 +35,11 @@ provisioner:
         vars:
           haproxy_ssl_dhparam_size: 512
     host_vars:
-      instance_haproxy_1:
+      instancehaproxy1:
         haproxy_create_self_signed_cert: true
         haproxy_ppa_version: 'ppa:vbernat/haproxy-2.4'
         haproxy_version: '2.4.*'
-      instance_haproxy_2:
+      instancehaproxy2:
         haproxy_create_self_signed_cert: false
         haproxy_ssl_cert_chain_src_file_path: "{{ (lookup('env', 'MOLECULE_SCENARIO_DIRECTORY'), 'test.pem') | path_join }}"
         haproxy_ppa_version: 'ppa:vbernat/haproxy-2.6'

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -11,7 +11,9 @@ global
     group {{ haproxy_group }}
     daemon
     stats socket {{ haproxy_socket }} user {{ haproxy_user }} group {{ haproxy_group }} mode 660 level admin
+    {% if haproxy_version is version('2.6', 'lt') %}
     nbproc {{ haproxy_nbproc }}
+    {% endif %}
     nbthread {{ haproxy_nbthread }}
     cpu-map {{ haproxy_cpumap }}
 


### PR DESCRIPTION
* Test the role against the HAProy LTS releases 2.4 and 2.6
* Install HAProxy 2.6 by default

Closes #34 