### PR TITLE
Remove variables `backends` and `frontend_ip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ haproxy_backends:
     backend_id: '192.168.33.10'
 ```
 
-:warning: The variable name `backends` is deprecated and will be removed in
-version 2.0.
-
 #### Frontend floating IP address
 
 Specify the floating IP address of the frontend:
@@ -57,9 +54,6 @@ Specify the floating IP address of the frontend:
 ```yaml
 haproxy_frontend_ip: '192.168.33.100'
 ```
-
-:warning: The variable name `frontend_ip` is deprecated and will be removed in
-version 2.0.
 
 ### Compulsory variables which are set by default but need to be adapted
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,31 +7,12 @@
 - name: Check that all mandatory variables are defined.
   ansible.builtin.assert:
     that:
-      # Support both variable names until version 2.0
-      - haproxy_backends is defined or backends is defined
-      - haproxy_frontend_ip is defined or frontend_ip is defined
+      - haproxy_backends is defined
+      - haproxy_frontend_ip is defined
       - haproxy_create_self_signed_cert or haproxy_ssl_cert_chain_src_file_path is defined
     fail_msg: "Some mandatory variables are not set."
     success_msg: "All mandatory variables are set."
   when: haproxy_config_template == "haproxy.cfg.j2"
-
-- name: Set haproxy_backends variable if not set.
-  when: haproxy_backends is not defined
-  ansible.builtin.set_fact:
-    haproxy_backends: "{{ backends | default() }}"
-- name: "Show Deprecation warning"
-  ansible.builtin.debug:
-    msg: "The variable 'backends' is deprecated and will be removed in version 2.0"
-  when: backends is defined
-
-- name: Set haproxy_frontend_ip variable if not set.
-  when: haproxy_frontend_ip is not defined
-  ansible.builtin.set_fact:
-    haproxy_frontend_ip: "{{ frontend_ip | default() }}"
-- name: "Show Deprecation warning"
-  ansible.builtin.debug:
-    msg: "The variable 'frontend_ip' is deprecated and will be removed in version 2.0"
-  when: frontend_ip is defined
 
 - name: Enable ip_forward.
   become: yes


### PR DESCRIPTION
These variables were deprecated and are now removed. Please use `haproxy_backends` and `haproxy_frontend_ip` instead.

Closes #2 