### PR TITLE
Feat: Add optional backend port

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ None.
 
 #### Backend GitLab IP addresses
 
-Specify a list of backends with name and IP address:
+Specify a list of backends with name and IP address (Port is optional, defaults to `80`):
  
 ```yaml
 haproxy_backends:
   - backend_name: 'backend_server_1'
     backend_ip: '192.168.33.10'
+    backend_port: '80'
 ```
 
 #### Frontend floating IP address
@@ -373,6 +374,7 @@ Note: This role is intended for use with, but not limited to, the
         haproxy_backends:
           - backend_name: 'backend_server_1'
             backend_ip: '192.168.33.10'
+            backend_port: 80
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Specify a list of backends with name and IP address:
 ```yaml
 haproxy_backends:
   - backend_name: 'backend_server_1'
-    backend_id: '192.168.33.10'
+    backend_ip: '192.168.33.10'
 ```
 
 #### Frontend floating IP address
@@ -372,7 +372,7 @@ Note: This role is intended for use with, but not limited to, the
         haproxy_frontend_ip: '192.168.33.100'
         haproxy_backends:
           - backend_name: 'backend_server_1'
-            backend_id: '192.168.33.10'
+            backend_ip: '192.168.33.10'
 ```
 
 ## License

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -65,5 +65,5 @@ backend gitlab
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     default-server check maxconn 20
     {% for backend in haproxy_backends %}
-    server {{ backend.backend_name }} {{ backend.backend_ip }}:80 check
+    server {{ backend.backend_name }} {{ backend.backend_ip }}:{{ backend.backend_port | default(80, true) }} check
     {% endfor %}


### PR DESCRIPTION
I had a use case where my backend was running on port 8080. Updated the playbook's haproxy.cfg file to include an optional backend variable, `haproxy_backends.backend_port` to set this value. Defaults to port 80.