### PR TITLE
Bypass Add PPA for HAProxy if haproxy_ppa_version is empty

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     validate_certs: yes
     mode: '0644'
   register: "ppa"
+  when: haproxy_ppa_version | length > 0
 
 - name: Check whether wildcard character is contained in version string.
   ansible.builtin.set_fact:


### PR DESCRIPTION
By setting `haproxy_ppa_version: ''` we can bypass the `Add PPA for HAProxy` action and we use the default debian repo package.
I think we should not rely on a thirdparty repo for this;or at least have an option to bypass this.
Works for me on my Raspberry Pi bookworm version.
